### PR TITLE
Enable auto fetch

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,10 @@
     // Use 'forwardPorts' to create a container with published ports.
     "forwardPorts": [3000],
 
-    // Use 'settings' to set *default* container specific settings.json values on container create. 
+    // Use 'settings' to set *default* container specific settings.json values on container create.
     "settings": {
         "terminal.integrated.shell.linux": "/bin/bash",
+        "git.autofetch": true,
     },
 
     // Add the IDs of VS Code extensions you want installed when the container is created in the array below.


### PR DESCRIPTION
This will remove the toast asking if you want to periodically auto-fetch in the background, by enabling that feature explicitly in settings. At first, I assumed you could get rid of the toast pop-up by just explicitly setting the setting to either true or false, but I guess they're just checking for true. I don't think this should cause problems in any way.